### PR TITLE
Fix breakage on Subject 2923 Campaigns

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function getWorldData(textArray, worldMode) {
     var currentMainLocation;
 
     if (worldMode == "#adventure") {
-        currentMainLocation = textArray[3].split("/")[1].split("_")[1]
+        currentMainLocation = textArray[1].split("/")[1].split("_")[1]
     } else {
         currentMainLocation = "Fairview"
     }
@@ -111,6 +111,12 @@ function getWorldData(textArray, worldMode) {
         var inSmallDungeon = true;
 
         textLine = textArray[i]
+
+        if (!textLine.split("/")[1]) {
+            // hack shit because I'm getting weird extra lines
+            // could perhaps safely remove this by starting at i=1
+            continue
+        }
 
         //translate world/region names to readable text
         if ( textLine.search("World_City") != -1) {
@@ -283,22 +289,30 @@ function showDataFile(e, o){
 
     text = e.target.result
     text = text.split("/Game/Campaign_Main/Quest_Campaign_Ward13.Quest_Campaign_Ward13")[0]
-    text = text.split("/Game/Campaign_Main/Quest_Campaign_City.Quest_Campaign_City")[1].replace(/Game/g,"\n")
+    main_campaign = text.split("/Game/Campaign_Main/Quest_Campaign_City.Quest_Campaign_City")[1]
+    if (main_campaign) {
+        text = main_campaign.replace(/Game/g,"\n")
+    } else { // subject 2923 campaign
+        text = text.split("/Game/Campaign_Clementine/Quests/WardPrime/Quest_WardPrime_Template.Quest_WardPrime_Template")[0]
+        text = text.split("/Game/World_Rural/Templates/Template_Rural_Overworld_02.Template_Rural_Overworld_02")[1].replace(/Game/g,"\n")
+    }
 
     textArray = text.split("\n")
 
-   adText = e.target.result
+    adText = e.target.result
 
-   adText = adText.split("\n")
-   tempList = []
-   for(i = 0; i < adText.length; i++)
-   {
-     if (String(adText[i]).includes('Adventure') === true)
-     {
-       tempList.push(adText[i])
-     }
-   }
-   adText = tempList[1]
+    adText = adText.split("\n")
+    tempList = []
+    for(i = 0; i < adText.length; i++)
+    {
+        if (String(adText[i]).includes('Adventure') === true)
+        {
+            tempList.push(adText[i])
+        }
+    }
+    // regardless of campaign type, the last line collected will have our current adventure data
+    adText = tempList[tempList.length - 1]
+   
     if (adText != undefined) {
         adventureMode = true
         adText = adText.replace(/Game/g,"\n")


### PR DESCRIPTION
- resolve issue #9 
- add logic to check the campaign type
- change the place in the save file where adventure mode data is taken
  - accomodates both campaign types
- no support for subject 2923 campaign events or reisum adventures yet, but this is the first step.

Tested on several save files, both my own and some sourced from friends. Cases tested:
- Main Campaign with Earth Adventure
- Subject 2923 Campaign with an Earth Adventure generated during a Main Campaign
- Subject 2923 Campaign with a Corsus Adventure
- Subject 2923 Campaign with a Rhom Adventure
- Subject 2923 Campaign with a Yaesha Adventure
- Subject 2923 Campaign with an Earth Adventure
- Main Campaign with a Rhom Adventure generated during a Subject 2923 Campaign