### PR TITLE
Fix to campaign mode data parse & display, fix to table generation (traitbooks, boss duplication)

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ function getWorldData(textArray, worldMode) {
             if (zone != undefined && eventType != undefined && eventName != undefined) {
 
                 if (zones[zone][eventType] != undefined) {
-                    if (zones[zone][eventType].search(eventName) == -1) {
+                    if (zones[zone][eventType].search(eventName) == -1 || eventName ==="TraitBook" ) {
                         zones[zone][eventType] += ", " + eventName
 
                         if (worldMode == "#adventure") {
@@ -279,7 +279,8 @@ function getWorldData(textArray, worldMode) {
                             mainLocationText = currentMainLocation.split(/(?=[A-Z])/).join(' ') + ": "
                         }
                         html = "<tr><td>" + zone + ": " + mainLocationText + currentSublocation.split(/(?=[A-Z])/).join(' ') +  "</td><td>" + eventType + "</td><td>" + eventName.split(/(?=[A-Z])/).join(' ') + "</td></tr>"
-                    }
+                        $(worldMode).append(html)
+		    }
                 } else {
                     zones[zone][eventType] = eventName
 
@@ -290,8 +291,8 @@ function getWorldData(textArray, worldMode) {
                         }
 
                         html = "<tr><td>" + zone + ": " + mainLocationText + currentSublocation.split(/(?=[A-Z])/).join(' ') +  "</td><td>" + eventType + "</td><td>" + eventName.split(/(?=[A-Z])/).join(' ') + "</td></tr>"
+                        $(worldMode).append(html)
                 }
-                $(worldMode).append(html)
             }
             $('#filters').show()
         }

--- a/index.js
+++ b/index.js
@@ -351,6 +351,9 @@ function showDataFile(e, o){
         adventureMode = false
     }
 
+    //always parse main campaign data
+    getWorldData(textArray, "#main")
+	
     if (adventureMode) {
         getWorldData(adTextArray, "#adventure")
 		
@@ -358,7 +361,6 @@ function showDataFile(e, o){
 		$('.adventure-mode').show()
 		$('#toggle-adv').text("Show Campaign Mode")
     } else {
-		getWorldData(textArray, "#main")
 		
 		$('.main-mode').show()
 		$('.adventure-mode').hide()


### PR DESCRIPTION
Fixed issue where main campaign data was never parsed when file contains adventure mode information. (If the save contains adventure mode data, the 'else' block on line 363 will never execute, resulting in only adventure mode data being parsed)